### PR TITLE
Update Kali install script to use dedicated key

### DIFF
--- a/kali_install.sh
+++ b/kali_install.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-echo "deb http://http.kali.org/kali kali-rolling main non-free contrib" | sudo tee /etc/apt/sources.list.d/kali.list
-wget -q -O - https://archive.kali.org/archive-key.asc | sudo apt-key add -
+echo "deb [signed-by=/usr/share/keyrings/kali-archive-keyring.gpg] http://http.kali.org/kali kali-rolling main non-free contrib" | sudo tee /etc/apt/sources.list.d/kali.list
+curl -fsSL https://archive.kali.org/archive-key.asc | sudo gpg --dearmor -o /usr/share/keyrings/kali-archive-keyring.gpg
 sudo apt update
 sudo apt install -y kali-linux-core kali-system-gui kali-linux-headless kali-tools-top10 kali-linux-default \
     kali-tools-information-gathering kali-tools-vulnerability-analysis kali-tools-web kali-tools-exploitation \


### PR DESCRIPTION
## Summary
- store the Kali archive signing key under `/usr/share/keyrings`
- reference the stored key via the `signed-by` option in the Kali repo entry

## Testing
- `bash -n kali_install.sh`

------
https://chatgpt.com/codex/tasks/task_e_687196919da88321b7e010b84af758ac